### PR TITLE
Upgrade/laravel 56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 This changelog contains all notable change of the laravel-translatable
 package
 
+1.3.0
+---
+
+- drops support for Laravel 5.4
+- adds support for Laravel 5.6
+
 v1.2.0
 ---
 - adds support for laravel auto-discovery

--- a/README.md
+++ b/README.md
@@ -22,16 +22,6 @@ You can install the package via composer:
 composer require aheenam/laravel-translatable
 ```
 
-If you are using Laravel in a version < 5.5, the service provider must be registered as a next step:
-
-```php
-// config/app.php
-'providers' => [
-    ...
-    Aheenam\Translatable\TranslatableServiceProvider::class,
-];
-```
-
 Now you can use this Trait on any Eloquent Model of your project.
 
 Usage

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
   "minimum-stability": "stable",
   "require": {
     "php" : "^7.0",
-    "illuminate/support": "~5.4.0|~5.5.0",
-    "illuminate/database": "~5.4.0|~5.5.0"
+    "illuminate/support": "~5.5.0|~5.6.0",
+    "illuminate/database": "~5.5.0|~5.6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.*|^6.3",
-    "orchestra/testbench": "~3.4.0|~3.5.0"
+    "phpunit/phpunit": "^6.3|^7.0",
+    "orchestra/testbench": "~3.5.0|~3.6.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Adds support for Laravel 5.6 while dropping it for 5.4. Closes #3.